### PR TITLE
include apt default recipe if debian

### DIFF
--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -3,7 +3,7 @@
 # Recipe:: packages
 #
 # Copyright (C) 2014 base2Services
-# 
+#
 # All rights reserved - Do Not Redistribute
 #
 
@@ -11,6 +11,8 @@
 
 if node['platform_family'] == 'rhel' and node['platform'] != 'amazon'
   include_recipe 'yum-epel'
+elsif node['platform_family'] == 'debian'
+  include_recipe 'apt'
 end
 
 node['common']['packages'].each do |p|


### PR DESCRIPTION
nrpe recipe fails without apt-get update.
includes apt default recipe.