### PR TITLE
wait for elb/alb scripts

### DIFF
--- a/files/default/opt/base2/bin/wait_for_alb
+++ b/files/default/opt/base2/bin/wait_for_alb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+
+# wait_for_alb.rb
+
+# Waits for a ec2 instance to become healthy in a specified target group
+
+# Required parameters
+#   '-r', '--region' - specify a aws region i.e. -r ap-southeast-2
+#   '-t', '--target-groups' - specify one or more target group arns seperated by comma i.e. -t arn::1,arn::2
+#   '-i', '--instance-id' - specify the ec2 instance id i.e. -i i-0a5c9e3f2ff024ce9
+
+require 'aws-sdk'
+
+# Set default timeout to 5 minutes
+timeout = "3600"
+
+until ARGV.empty?
+  if ARGV.first.start_with?('-')
+    case ARGV.shift
+    when '-r', '--region'
+      region = ARGV.shift
+    when '-t', '--target-groups'
+      target_groups = ARGV.shift.split(",")
+    when '-i', '--instance-id'
+      instance_id = ARGV.shift
+    when '-T', '--timeout'
+      timeout = ARGV.shift
+    end
+  else
+    ARGV.shift
+  end
+end
+
+if !region || !target_groups || !instance_id
+  abort "ERROR: one or more parameters not supplied\nRequired `--instance-id`, `--target-groups`, `--region`"
+end
+
+client = Aws::ElasticLoadBalancingV2::Client.new(region: region)
+
+started_at = Time.now
+
+target_groups.each do |tg|
+
+  in_service = false
+
+  until in_service
+    resp = client.describe_target_health({
+      target_group_arn: tg,
+      targets: [{id: instance_id}]
+    })
+    tg.gsub(/(\/(.*?)\/)/) {puts "TG: #{$1.gsub('/','')}"}
+    state = resp.target_health_descriptions[0].target_health.state
+    if state == 'healthy'
+      puts "STATUS: #{state}"
+      in_service = true
+    elsif Time.now - started_at > timeout
+      puts "ERROR: failed to wait for instance to come into service..."
+      exit 1
+    else
+      puts "STATUS: #{state}"
+      sleep 5
+    end
+  end
+end

--- a/files/default/opt/base2/bin/wait_for_elb
+++ b/files/default/opt/base2/bin/wait_for_elb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+
+# wait_for_elb.rb
+
+# Waits for a ec2 instance to become healthy in one ore more classic elastic load balancers
+# Queries all elastic load balancers in the region for the instance-id
+
+# Required parameters
+#   '-r', '--region' - specify a aws region i.e. -r ap-southeast-2
+#   '-i', '--instance-id' - specify the ec2 instance id i.e. -i i-0a5c9e3f2ff024ce9
+
+require 'aws-sdk'
+
+timeout = "3600" # Default timeout set to 5 minutes
+
+until ARGV.empty?
+  if ARGV.first.start_with?('-')
+    case ARGV.shift
+    when '-r', '--region'
+      region = ARGV.shift
+    when '-i', '--instance-id'
+      instance_id = ARGV.shift
+    when '-T', '--timeout'
+      timeout = ARGV.shift
+    end
+  else
+    ARGV.shift
+  end
+end
+
+if !region || !instance_id
+  abort "ERROR: one or more parameters not supplied\nRequired `--instance-id`, `--region`"
+end
+
+client = Aws::ElasticLoadBalancing::Client.new( region: region )
+
+elbs = []
+
+resp = client.describe_load_balancers()
+
+resp.load_balancer_descriptions.each do |load_balancer|
+  load_balancer.instances.each do |instance|
+    if instance.instance_id == instance_id
+      elbs << load_balancer.load_balancer_name
+    end
+  end
+end
+
+puts ""
+puts elbs
+
+elbs.each do |elb|
+  begin
+    started_at = Time.now
+    client.wait_until(:instance_in_service, load_balancer_name: elb, instances:[{ instance_id: instance_id }]) do |w|
+      w.max_attempts = nil
+      w.before_wait do |attempts, response|
+        puts "STATUS: #{response.instance_states[0].state}"
+        throw :failure if Time.now - started_at > timeout
+      end
+    end
+  rescue Aws::Waiters::Errors::WaiterFailed => e
+    abort "ERROR: #{e}"
+  end
+end

--- a/recipes/directories.rb
+++ b/recipes/directories.rb
@@ -29,7 +29,7 @@ base2_opt_dir_extras.each do |dir|
   end
 end
 
-['ec2-bootstrap', 'ec2-bootstrap.py', 'find_asg_ip'].each do | file |
+['ec2-bootstrap', 'ec2-bootstrap.py', 'find_asg_ip', 'wait_for_alb', 'wait_for_elb'].each do | file |
   cookbook_file "/opt/base2/bin/#{file}" do
     source "opt/base2/bin/#{file}"
     owner 'root'

--- a/spec/directories_spec.rb
+++ b/spec/directories_spec.rb
@@ -27,4 +27,12 @@ describe 'base2::directories' do
     expect(chef_run).to create_cookbook_file('/opt/base2/bin/find_asg_ip')
   end
 
+  it 'should create the base2 wait_for_alb script' do
+    expect(chef_run).to create_cookbook_file('/opt/base2/bin/wait_for_alb')
+  end
+
+  it 'should create the base2 wait_for_elb script' do
+    expect(chef_run).to create_cookbook_file('/opt/base2/bin/wait_for_elb')
+  end
+
 end


### PR DESCRIPTION
Replacing ruby block in chef runtime recipe. Call from userdata in cloudformation after chef run.

```ruby
"/opt/base2/bin/wait_for_elb -r ", Ref("AWS::Region"), " -i $INSTANCE_ID\n",
"/opt/base2/bin/wait_for_alb -r ", Ref("AWS::Region"), " -i $INSTANCE_ID -t", Ref("TargetGroupA"), ",", Ref("TagetGroupB")," -T 2000\n",
```

Timeout defaults to 5 minutes
Command options can be used in any order and will handle any unknown options or parameters by either ignoring them if it can or aborting the script.
Script will also abort if all required parameters are not present