### PR TITLE
Script to get SSM Parameters and add to override file

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,7 @@
 
 default['system']['timezone'] = "Australia/Melbourne"
 default['common']['packages'] = ['telnet', 'mc', 'screen', 'sysstat','traceroute']
+default['common']['gems'] = ['aws-sdk']
 default['common']['user'] = 'base2'
 
 default['base2']['docker']['images'] = []

--- a/files/default/opt/base2/bin/ec2-bootstrap
+++ b/files/default/opt/base2/bin/ec2-bootstrap
@@ -27,6 +27,7 @@ export AWS_REGION=$AWS_REGION
 export DATA_VOLUME_ID=$DATA_VOLUME_ID
 export INSTANCE_ID=$INSTANCE_ID
 export AWS_ACCOUNT_ID=$AWS_ACCOUNT_ID
+export EC2_TAG_SSM_PARAMETERS="`get_tag` 'SSMParameters'"
 
 #create an environment in a dynamic way
 #if they don't exist
@@ -59,6 +60,11 @@ cat <<EOT > /etc/chef/override.json
   }
 }
 EOT
+
+if [[ $EC2_TAG_SSM_PARAMETERS -eq "true" ]]; then
+  echo "Executing get_ssm_parameters for environment $EC2_TAG_ENVIRONMENT"
+  ruby /opt/base2/bin/get_ssm_parameters -r $AWS_REGION -e $EC2_TAG_ENVIRONMENT
+fi
 
 echo "Executing bootstrap for $EC2_TAG_ROLE for environment $EC2_TAG_ENVIRONMENT"
 

--- a/files/default/opt/base2/bin/get_ssm_parameters
+++ b/files/default/opt/base2/bin/get_ssm_parameters
@@ -37,9 +37,7 @@ if !region || !environment
   abort "ERROR: one or more parameters not supplied\nRequired `--region`, `--environment`"
 end
 
-
-credentials = Aws::SharedCredentials.new(profile_name: 'conctr-dev')
-ssm = Aws::SSM::Client.new(region: region, credentials: credentials)
+ssm = Aws::SSM::Client.new(region: region)
 
 # Initalize parameter name array
 parameters = []

--- a/files/default/opt/base2/bin/get_ssm_parameters
+++ b/files/default/opt/base2/bin/get_ssm_parameters
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+
+# get_secrets
+
+# Gets secrets from ssm parameters
+
+# Parameters
+#   '-r', '--region' - specify a aws region i.e. -r ap-southeast-2 [Required]
+#   '-e', '--environment' - specify environment name [Required]
+#   '-o', '--override-file' - specify the location of the override file [Optional]
+#   '-d', '--delimiter' - specify a custom delimiter in your parameters
+
+require 'aws-sdk'
+
+# Defaults
+override_file = "/etc/chef/override.json"
+parameter_delimiter = ".."
+
+until ARGV.empty?
+  if ARGV.first.start_with?('-')
+    case ARGV.shift
+    when '-r', '--region'
+      region = ARGV.shift
+    when '-e', '--environment-name'
+      environment = ARGV.shift
+    when '-o', '--override-file'
+      override_file = ARGV.shift
+    when '-d', '--delimiter'
+      parameter_delimiter = ARGV.shift
+    end
+  else
+    ARGV.shift
+  end
+end
+
+if !region || !environment
+  abort "ERROR: one or more parameters not supplied\nRequired `--region`, `--environment`"
+end
+
+
+credentials = Aws::SharedCredentials.new(profile_name: 'conctr-dev')
+ssm = Aws::SSM::Client.new(region: region, credentials: credentials)
+
+# Initalize parameter name array
+parameters = []
+
+# Get all default parameters
+default_params = ssm.describe_parameters({filters: [{ key: "Name", values: ["default"] }]})
+default_params.parameters.each { |param| parameters << param.name } if default_params.parameters.any?
+
+# Get all environment specific parameters
+environ_params = ssm.describe_parameters({filters: [{ key: "Name", values: [environment] }]})
+environ_params.parameters.each { |param| parameters << param.name } if environ_params.parameters.any?
+
+# Exit 1 if no parameters are found
+abort("ERROR: No secrets found in #{environment} environment or default parameter sets") unless parameters.any?
+
+secrets = ssm.get_parameters({
+  names: parameters,
+  with_decryption: true,
+})
+
+override = {}
+secrets.parameters.each do |s|
+  attributes = s.name.split(parameter_delimiter).drop(1)
+  i = 0;
+  attributes.reduce(override) do |hash,key|
+    hash[key] = if (i += 1) == attributes.length
+      s.value
+    else
+      hash[key] || {}
+    end
+  end
+end
+
+if File.file?(override_file)
+  puts "INFO: #{override_file} exits. Loading file..."
+  temp_override = JSON.parse(File.read(override_file))
+  override.merge!(temp_override)
+end
+
+puts "INFO: Writing secrets to #{override_file}"
+File.open(override_file,"w") { |f| f.write(JSON.pretty_generate(override))}

--- a/recipes/directories.rb
+++ b/recipes/directories.rb
@@ -29,7 +29,7 @@ base2_opt_dir_extras.each do |dir|
   end
 end
 
-['ec2-bootstrap', 'ec2-bootstrap.py', 'find_asg_ip', 'wait_for_alb', 'wait_for_elb'].each do | file |
+['ec2-bootstrap', 'ec2-bootstrap.py', 'find_asg_ip', 'wait_for_alb', 'wait_for_elb', 'get_ssm_parameters'].each do | file |
   cookbook_file "/opt/base2/bin/#{file}" do
     source "opt/base2/bin/#{file}"
     owner 'root'

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -19,6 +19,10 @@ node['common']['packages'].each do |p|
   package p
 end
 
+node['common']['gems'].each do |p|
+  gem_package p
+end
+
 execute "Upgrade awscli" do
   command "pip install --upgrade awscli"
   only_if "curl -s http://instance-data.ec2.internal"

--- a/spec/directories_spec.rb
+++ b/spec/directories_spec.rb
@@ -35,4 +35,9 @@ describe 'base2::directories' do
     expect(chef_run).to create_cookbook_file('/opt/base2/bin/wait_for_elb')
   end
 
+  it 'should create the base2 get_ssm_parameters script' do
+    expect(chef_run).to create_cookbook_file('/opt/base2/bin/get_ssm_parameters')
+  end
+
+
 end


### PR DESCRIPTION
Requires the tag `SSMParameters` set to `true` on the ec2 instance for the bootstrap to run the script.
packages recipe will install the aws-sdk gem globally by default

Parameter names are formatted as the following wil `..` as the default delimiter
```
default..base2..app..SECRET
```
the first word is the environment or default which is a global parameter. An environment parameter will override a deafult.
The last work is the secret key.

The output is a chef attribute in the override.json 
```
node['base2']['app']['SECRET'] = "value"
```