### PR TITLE
ssm parameters into override for windows

### DIFF
--- a/recipes/windows_directories.rb
+++ b/recipes/windows_directories.rb
@@ -30,3 +30,7 @@ end
 cookbook_file "#{base2_opt_dir}/bin/EC2-Bootstrap.ps1" do
   source "windows/EC2-Bootstrap.ps1"
 end
+
+cookbook_file "#{base2_opt_dir}/bin/get_ssm_parameters" do
+  source "opt/base2/bin/get_ssm_parameters"
+end


### PR DESCRIPTION
Requires the tag SSMParameters set to true on the ec2 instance for the bootstrap to run the script.
packages recipe will install the aws-sdk gem globally by default

Parameter names are formatted as the following with `..` as the default delimiter

```default..base2..app..SECRET```

the first word is the environment or default which is a global parameter. An environment parameter will override a deafult.
The last work is the secret key.

The output is a chef attribute in the override.json

```node['base2']['app']['SECRET'] = "value"```