### PR TITLE
Ruby Aws-Sdk compatibility with codedeploy

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,7 +9,7 @@
 
 default['system']['timezone'] = "Australia/Melbourne"
 default['common']['packages'] = ['telnet', 'mc', 'screen', 'sysstat','traceroute']
-default['common']['gems'] = ['aws-sdk']
+default['common']['gems'] = ['aws-sdk@2.9.44']
 default['common']['user'] = 'base2'
 
 default['base2']['docker']['images'] = []

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -20,7 +20,16 @@ node['common']['packages'].each do |p|
 end
 
 node['common']['gems'].each do |p|
-  gem_package p
+  package_name = p
+  package_version = nil
+  # support for both [gemname] and [gemname@version] spec
+  if p.include?('@')
+    package_name = p.split('@')[0]
+    package_version = p.split('@')[1]
+  end
+  gem_package package_name do
+    version package_version unless package_version.nil?
+  end
 end
 
 execute "Upgrade awscli" do


### PR DESCRIPTION
Pinning down version of installed aws-sdk ruby gem to 2.9.44, released on June 20, 2017 which is pretty fresh. 2.10.xx will cause problems to codedeploy which will fail to start with this gem version. 

`common.gems` node property now accepts `gemname@gemversion` format, as well as only `gemname`  