### PR TITLE
wait for tags to populate on ec2 instance in bash bootstrap

### DIFF
--- a/files/default/opt/base2/bin/ec2-bootstrap
+++ b/files/default/opt/base2/bin/ec2-bootstrap
@@ -14,9 +14,21 @@ if [ ! "x$2" == x ]; then
 fi
 
 function get_tag {
-    tag="`aws ec2 describe-tags --region ${AWS_REGION} --filters "Name=resource-id,Values=$INSTANCE_ID" "Name=key,Values=$1" --output=text | cut -f5`"
+    tag="`aws ec2 describe-tags --region ${AWS_REGION} --filters "Name=resource-id,Values=${INSTANCE_ID}" "Name=key,Values=$1" --output=text | cut -f5`"
     echo "$tag"
 }
+
+# Wait until tags are populated before getting values for override.json
+while true; do
+  TAGS=$(aws --region ${REGION} ec2 describe-tags --filters Name=resource-id,Values=${INSTANCEID} --query 'Tags[].Value' --output=text)
+  if [ ${#TAGS[@]} -eq 0 ]; then
+    echo "INFO: Tags not populated yet..."
+    sleep 1
+  else
+    echo "INFO: Tags are available"
+    break
+  fi
+done
 
 export EC2_TAG_ENVIRONMENT="`get_tag 'Environment'`"
 export EC2_TAG_ENVIRONMENT_TYPE="`get_tag 'EnvironmentType'`"

--- a/files/default/opt/base2/bin/ec2-bootstrap
+++ b/files/default/opt/base2/bin/ec2-bootstrap
@@ -18,17 +18,31 @@ function get_tag {
     echo "$tag"
 }
 
-# Wait until tags are populated before getting values for override.json
-while true; do
-  TAGS=$(aws --region ${REGION} ec2 describe-tags --filters Name=resource-id,Values=${INSTANCEID} --query 'Tags[].Value' --output=text)
+function log() {
+  LEVEL="${1^^}"
+  MESSAGE="$2"
+  DATESTAMP="`date +%r`"
+
+  echo "${DATESTAMP} [${LEVEL}] -- ${MESSAGE}"
+}
+
+RETRIES=0
+TIMEOUT=30
+while [ $RETRIES -lt $TIMEOUT ]; do
+  TAGS=($(aws --region ${REGION} ec2 describe-tags --filters Name=resource-id,Values=${INSTANCEID} --query 'Tags[].Value' --output=text))
   if [ ${#TAGS[@]} -eq 0 ]; then
-    echo "INFO: Tags not populated yet..."
+    log "INFO" "Tags not populated yet..."
     sleep 1
   else
-    echo "INFO: Tags are available"
+    log "INFO" "Tags are available"
     break
   fi
+  ((RETRIES++))
 done
+
+if [ $RETRIES -eq $TIMEOUT ]; then
+  log 'ERROR' "Desribe tags returned nothing within the timeout of ${TIMEOUT} seconds"
+fi
 
 export EC2_TAG_ENVIRONMENT="`get_tag 'Environment'`"
 export EC2_TAG_ENVIRONMENT_TYPE="`get_tag 'EnvironmentType'`"
@@ -74,11 +88,11 @@ cat <<EOT > /etc/chef/override.json
 EOT
 
 if [[ "${EC2_TAG_SSM_PARAMETERS}" == "true" ]]; then
-  echo "Executing get_ssm_parameters for environment $EC2_TAG_ENVIRONMENT"
+  log 'INFO' "Executing get_ssm_parameters for environment $EC2_TAG_ENVIRONMENT"
   ruby /opt/base2/bin/get_ssm_parameters -r $AWS_REGION -e $EC2_TAG_ENVIRONMENT
 fi
 
-echo "Executing bootstrap for $EC2_TAG_ROLE for environment $EC2_TAG_ENVIRONMENT"
+log 'INFO' "Executing bootstrap for $EC2_TAG_ROLE for environment $EC2_TAG_ENVIRONMENT"
 
 CLI_OPTS=""
 if [[ -f "/etc/chef/environments/${EC2_TAG_ENVIRONMENT_TYPE}.json" ]]; then


### PR DESCRIPTION
We are seeing the boot strap run with nothing in the override.json happen quite frequently now that instances are coming up much faster.

This should solve this by waiting for tags to become populated before populating the override.json