### PR TITLE
Add script to attach EBS volume on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ Call from userdata in cloudformation.
 `-d` `--device-index` - specify device index for eni, defaults to 1 [Optional]<br />
 `-T` `--timeout` - specify timeout for script, defaults to 600 [Optional]
 
+
+## attach_ebs
+**Suported OS:** Linux, Windows (untested)
+
+##### Purpose
+Attaches an Elastic block Store to an EC2 instance based on a tag or volume.
+
+##### Usage
+Call from userdata in cloudformation.
+```
+/opt/base2/bin/attach_ebs -r <AWS::Region> -t <tag>
+```
+
+#### Options
+`-r` `--region` - specify a aws region i.e. -r ap-southeast-2 <br />
+`-t` `--tag` - specify eni reservation tag [Required if -v or --volume not specified]<br />
+`-v` `--volume` - specify volume [Required if -t or --tag not specified]<br />
+`-d` `--device` - specify volume device type, defaults to /dev/xvdb [Optional]<br />
+`-T` `--timeout` - specify timeout for script, defaults to 600 [Optional]
+
 # Author
 
 Author:: itsupport@base2services.com

--- a/attributes/files.rb
+++ b/attributes/files.rb
@@ -1,0 +1,9 @@
+default['base2']['scripts'] = [
+	'ec2-bootstrap', 
+	'ec2-bootstrap.py', 
+	'find_asg_ip', 
+	'wait_for_alb', 
+	'wait_for_elb',
+	'get_ssm_parameters',
+	'attach_ebs',
+	'attach_eni']

--- a/files/default/opt/base2/bin/attach_ebs
+++ b/files/default/opt/base2/bin/attach_ebs
@@ -1,0 +1,162 @@
+#!/usr/bin/env ruby
+
+# attach_ebs
+
+# Attaches an EBS to the running instance
+
+# Parameters
+#   '-r', '--region' - specify a aws region i.e. -r ap-southeast-2 [Required]
+#   '-t', '--tag' - specify ebs reservation tag [Required if -v or --volume not specified]
+#   '-v', '--volume' - specify ebs id [Required if -t or --tag not specified]
+#   '-d', '--device' - specify device for ebs
+#   '-T', '--timeout' - specify timeout for script [Optional]
+
+require 'aws-sdk'
+require 'net/http'
+
+## Defaults
+$timeout_seconds = 600 # seconds
+device = '/dev/xvdb'
+
+## Get instance ID from metadata service
+metadata_endpoint = 'http://169.254.169.254/latest/meta-data/'
+instance_id = Net::HTTP.get( URI.parse( metadata_endpoint + 'instance-id' ) )
+
+until ARGV.empty?
+  if ARGV.first.start_with?('-')
+    case ARGV.shift
+    when '-r', '--region'
+      region = ARGV.shift
+    when '-t', '--tag'
+      tag = ARGV.shift
+    when '-d', '--device'
+      device = ARGV.shift
+    when '-v', '--volume'
+      volume = ARGV.shift
+    when '-T', '--timeout'
+      $timeout_seconds = ARGV.shift.to_i
+    end
+  else
+    ARGV.shift
+  end
+end
+
+
+## Set script timeout time (epoch)
+$timeout_time = Time.now.to_i + $timeout_seconds
+
+if !region || (!volume && !tag)
+  abort "ERROR: one or more parameters not supplied\nRequired `--region`, `--tag` or `--volume`"
+end
+
+## Exit script if current time is later than the timeout time
+def timeout_exit
+  if Time.now.to_i > $timeout_time
+    abort "timed out after #{$timeout_seconds} seconds"
+  end
+end
+
+## Detach ebs from the instance it is currently attached to, and wait until the ebs is in a detached state
+def detach_ebs (client,ebs_volume_id,ebs_instance_id,volume,tag,ebs_status='')
+  puts "detaching #{ebs_volume_id} from #{ebs_instance_id}"
+  resp = client.detach_volume({volume_id: ebs_volume_id})
+  while ebs_status != 'available' do
+    if !volume.nil?
+      ebs_status = client.describe_volumes({volume_ids: [volume]}).volumes[0].state
+    else
+      ebs_status = client.describe_volumes({ filters: [ { name: "tag:reservation", values: [tag] } ] }).volumes[0].state
+    end
+    puts "ebs status: #{ebs_status}"
+    timeout_exit
+    sleep 2
+  end
+end
+
+## Attach ebs to the current instance, and wait until the ebs is in a attaced state
+def attach_ebs (client,ebs_volume_id,instance_id,tag,device,volume,ebs_status='')
+  puts "attaching #{ebs_volume_id} to #{instance_id}"
+  resp = client.attach_volume({
+    device: device,
+    instance_id: instance_id,
+    volume_id: ebs_volume_id
+  })
+  while ebs_status != 'in-use' do
+    if !volume.nil?
+      ebs_status = client.describe_volumes({volume_ids: [volume]}).volumes[0].state
+    else
+      ebs_status = client.describe_volumes({ filters: [ { name: "tag:reservation", values: [tag] } ] }).volumes[0].state
+    end
+    puts "ebs status: #{ebs_status}"
+    timeout_exit
+    sleep 2
+  end
+end
+
+## Get current status of ebs volumes
+begin
+client = Aws::EC2::Client.new(region: region)
+  if !volume.nil?
+    ebs_resp = client.describe_volumes({volume_ids: [volume]})
+  else
+    ebs_resp = client.describe_volumes({ filters: [ { name: "tag:reservation", values: [tag] } ] })
+  end
+rescue Aws::EC2::Errors::ServiceError => e
+  puts "ERROR: #{e}"
+end
+
+## If ebs exists, store attributes and deplay them
+if defined?(ebs_resp.volumes) && !ebs_resp.volumes[0].nil?
+  ebs_status = ebs_resp.volumes[0].state
+  ebs_volume_id = ebs_resp.volumes[0].volume_id
+  if ebs_status == 'in-use'
+    ebs_instance_id = ebs_resp.volumes[0].attachments[0].instance_id
+  end
+
+  puts "------------------------------------------------"
+  puts "attach_ebs"
+  puts "------------------------------------------------"
+  puts "running instance:            #{instance_id}"
+  puts "ebs id:                      #{ebs_volume_id}"
+  puts "ebs status:                  #{ebs_status}"
+  puts "attached instance:           #{ebs_instance_id}"
+  puts "------------------------------------------------"
+
+  ## If the ebs is attached to another instance, detach it and attach it to this instance
+  ## If the ebs isn't attached to an instance, attach it to this instance
+  if ebs_status != 'available'
+    if instance_id != ebs_instance_id
+      detach_ebs(client,ebs_volume_id,ebs_instance_id,volume,tag)
+      attach_ebs(client,ebs_volume_id,instance_id,tag,device,volume)
+    end
+  else
+    attach_ebs(client,ebs_volume_id,instance_id,tag,device,volume)
+  end
+
+  ## Get updated status of ebs (after detachment/attachment)
+  begin
+    if !volume.nil?
+      ebs_resp = client.describe_volumes({volume_ids: [volume]})
+    else
+      ebs_resp = client.describe_volumes({ filters: [ { name: "tag:reservation", values: [tag] } ] })
+    end
+  rescue Aws::EC2::Errors::ServiceError => e
+    puts "ERROR: #{e}"
+  end
+
+  ebs_status = ebs_resp.volumes[0].state
+  if ebs_status == 'in-use'
+    ebs_instance_id = ebs_resp.volumes[0].attachments[0].instance_id
+  else
+    ebs_instance_id = 'no instance'
+  end
+
+  puts "ebs #{ebs_volume_id} attached to #{ebs_instance_id}"
+  puts "------------------------------------------------"
+else
+  ## Display error if  ebs could not be found
+  if !volume.nil?
+    abort "ERROR: ebs with volume id '#{volume}' not found"
+  else
+    abort "ERROR: ebs with reservation tag '#{tag}' not found"
+  end
+end

--- a/recipes/directories.rb
+++ b/recipes/directories.rb
@@ -29,7 +29,7 @@ base2_opt_dir_extras.each do |dir|
   end
 end
 
-['ec2-bootstrap', 'ec2-bootstrap.py', 'find_asg_ip', 'wait_for_alb', 'wait_for_elb','get_ssm_parameters','attach_ebs','attach_eni'].each do | file |
+node['base2']['scripts'].each do | file |
   cookbook_file "/opt/base2/bin/#{file}" do
     source "opt/base2/bin/#{file}"
     owner 'root'

--- a/recipes/directories.rb
+++ b/recipes/directories.rb
@@ -29,7 +29,7 @@ base2_opt_dir_extras.each do |dir|
   end
 end
 
-['ec2-bootstrap', 'ec2-bootstrap.py', 'find_asg_ip', 'wait_for_alb', 'wait_for_elb', 'get_ssm_parameters'].each do | file |
+['ec2-bootstrap', 'ec2-bootstrap.py', 'find_asg_ip', 'wait_for_alb', 'wait_for_elb','get_ssm_parameters','attach_ebs','attach_eni'].each do | file |
   cookbook_file "/opt/base2/bin/#{file}" do
     source "opt/base2/bin/#{file}"
     owner 'root'

--- a/spec/directories_spec.rb
+++ b/spec/directories_spec.rb
@@ -39,5 +39,12 @@ describe 'base2::directories' do
     expect(chef_run).to create_cookbook_file('/opt/base2/bin/get_ssm_parameters')
   end
 
+  it 'should create the base2 attach_ebs script' do
+    expect(chef_run).to create_cookbook_file('/opt/base2/bin/attach_ebs')
+  end
+
+  it 'should create the base2 attach_eni script' do
+    expect(chef_run).to create_cookbook_file('/opt/base2/bin/attach_eni')
+  end
 
 end


### PR DESCRIPTION
This script would replace the current bash user data scripts we use to attach EBS volume to autoscaling instances.

The current scripts sometime fail when it takes longer than expected for an EBS volume to be detached from the previous instance.

This script should be more reliable as it waits until the EBS volume is in the AVAILABLE state before attaching it to the instance.